### PR TITLE
Removed unnecessary "module" word from require path.

### DIFF
--- a/autocomplete.lua
+++ b/autocomplete.lua
@@ -4,7 +4,7 @@
 -- @license MIT (see LICENSE)
 -- @module autocomplete
 
-local crates, config = require("modules.rust.config")
+local crates, config = require("rust.config")
 
 local _RUST = _USERHOME .. '/modules/rust/ta/'
 local _RUSTSRC = "/data/Code/rust/src"

--- a/init.lua
+++ b/init.lua
@@ -14,8 +14,8 @@ local raw = require("rust.builder.raw")
 textadept.editing.api_files.rust = completer.api_files
 textadept.editing.autocompleters.rust = completer.autocomplete
 
-local _keys = require("modules.rust.keys")
-local _snippets = require("modules.rust.snippets")
+local _keys = require("rust.keys")
+local _snippets = require("rust.snippets")
 
 if io.get_project_root() then
   api.add_apitag(raw.get_project_name())


### PR DESCRIPTION
init.lua and autocomplete.lua contains extra module word in couple of require.

Without this modifications TextAdept give an error when opening a rust file complaining about not found modules.