### PR TITLE
Fix a typo in the attribute token definition.

### DIFF
--- a/rust.lua
+++ b/rust.lua
@@ -64,7 +64,7 @@ local identifier = token(l.IDENTIFIER, l.word)
 local operator = token(l.OPERATOR, S('+-/*%<>!=`^~@&|?#~:;,.()[]{}'))
 
 -- Attributes.
-local attribute = token('attribute', S('#![')^1 *
+local attribute = token('attribute', P('#![')^1 *
                         (l.nonnewline - ']')^0 * P("]")^-1)
 
 M._rules = {


### PR DESCRIPTION
I noticed that an expression with `!=` was being styled as an attribute from that point.