### PR TITLE
Add sq_str into the "string" lexer

### DIFF
--- a/rust.lua
+++ b/rust.lua
@@ -23,7 +23,7 @@ local comment = token(l.COMMENT, line_comment + block_comment)
 local sq_str = P('L')^-1 * l.delimited_range("'")
 local dq_str = P('L')^-1 * l.delimited_range('"')
 local raw_str =  '#"' * (l.any - '#')^0 * P('#')^-1
-local string = token(l.STRING, dq_str + raw_str)
+local string = token(l.STRING, dq_str + raw_str + sq_str)
 
 -- Numbers.
 local number = token(l.NUMBER, l.float + (l.dec_num + "_")^1 +


### PR DESCRIPTION
Fixing odd formatting in the presence of things like `'\"'` (everything following becomes a string literal).