### PR TITLE
Don't automatically turn on trailing space removal.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -48,7 +48,6 @@ events.connect(events.LEXER_LOADED, function (lang)
   buffer.tab_width = 4
   buffer.use_tabs = false
   buffer.edge_column = 99
-  textadept.editing.STRIP_TRAILING_SPACES = true
 end)
 
 local function fmt()


### PR DESCRIPTION
Issues don't seem to be turned on for this repo (or the bitbucket one), so I'm using the medium of pull requests!

I (humbly, of course) think that setting STRIP_TRAILING_SPACES should be a user's option, not decided by a language module, and in particular it's not what I want when I have _RUSTFMT disabled to avoid my source (or, more importantly, a third party's source) changing in unexpected places when I save.

While I think of it, it might be nice to be able to set _RUSTFMT per-buffer (eg as buffer._RUSTFMT); as I might want to turn it on in my project's source files, but not in the external crate it uses which I'm submitting changes to.